### PR TITLE
Use Lingua::EN::Sentence directly to get offsets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ matrix:
   allow_failures:
     - perl: blead       # ignore failures for blead perl
 before_install:
-  - export DEVOPS_BRANCH="42-cpanfile-git-cache"
+  - export DEVOPS_BRANCH="master"
   - eval "$(curl https://raw.githubusercontent.com/project-renard/devops/$DEVOPS_BRANCH/script/helper.pl | perl -- | awk '/^#START/,/^#END/ { print > "/dev/stdout"; next } { print > "/dev/stderr"}' )"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
   directories:
     # local::lib caching
     - $HOME/perl5
+    - maint/cpanfile-git-log
 addons:
   apt:
     packages:
@@ -33,5 +34,5 @@ matrix:
   allow_failures:
     - perl: blead       # ignore failures for blead perl
 before_install:
-  - export DEVOPS_BRANCH="master"
+  - export DEVOPS_BRANCH="42-cpanfile-git-cache"
   - eval "$(curl https://raw.githubusercontent.com/project-renard/devops/$DEVOPS_BRANCH/script/helper.pl | perl -- | awk '/^#START/,/^#END/ { print > "/dev/stdout"; next } { print > "/dev/stderr"}' )"

--- a/Changes
+++ b/Changes
@@ -1,10 +1,8 @@
-NEXT
+0.001
   Features
 
    - First release.
-
-  Refactoring
-
-  Bug fixes
-
-  Build changes
+   - A function to process sentences for a String::Tagged representation of a
+     page.
+   - A function to preprocess acronyms in sentences for use with speech
+     synthesis.

--- a/dist.ini
+++ b/dist.ini
@@ -6,3 +6,6 @@ copyright_year   = 2017
 version = 0.001
 
 [@Author::ZMUGHAL::ProjectRenard]
+
+; [Test::PodSpelling]
+Test::PodSpelling.stopwords[ 0] = preprocess

--- a/lib/Renard/Incunabula/Language/EN.pm
+++ b/lib/Renard/Incunabula/Language/EN.pm
@@ -59,6 +59,12 @@ fun _get_offsets( $text ) {
 		# spaces.  This is due to Lingua::EN::Sentence
 		# having the `clean_sentences()` step.
 		my $s_re = quotemeta($s) =~ s/(\\\s)+/\\s+/gr;
+
+		# We use the 'g' option here because it keeps
+		# track of the previous regex position.
+		#
+		# This makes sure that repeated sentences have
+		# different offsets.
 		$str =~ m/$s_re/g;
 		push @$offsets, [ $-[0], $+[0] ];
 

--- a/lib/Renard/Incunabula/Language/EN.pm
+++ b/lib/Renard/Incunabula/Language/EN.pm
@@ -55,7 +55,10 @@ fun _get_offsets( $text ) {
 	my $offsets = [];
 	my $str = $text;
 	for my $s (@$sentences) {
-		my $s_re = $s =~ s/\s+/\\s+/gr;
+		# Make the search insensitive to internal
+		# spaces.  This is due to Lingua::EN::Sentence
+		# having the `clean_sentences()` step.
+		my $s_re = quotemeta($s) =~ s/(\\\s)+/\\s+/gr;
 		$str =~ m/$s_re/g;
 		push @$offsets, [ $-[0], $+[0] ];
 

--- a/lib/Renard/Incunabula/Language/EN.pm
+++ b/lib/Renard/Incunabula/Language/EN.pm
@@ -13,9 +13,6 @@ use Text::Unidecode;
 Retrieves the sentence offsets for each part of the C<$text> string that has
 been tagged as a C<block> and apply a C<sentence> tag to each sentence.
 
-This uses L<Lingua::EN::Sentence::Offsets> internally to determine the location
-of each sentence.
-
 =cut
 fun apply_sentence_offsets_to_blocks( (InstanceOf['String::Tagged']) $text ) {
 	$text->iter_extents_nooverlap(
@@ -37,6 +34,17 @@ fun apply_sentence_offsets_to_blocks( (InstanceOf['String::Tagged']) $text ) {
 	);
 }
 
+=func _get_offsets
+
+  fun _get_offsets( $text )
+
+This uses L<Lingua::EN::Sentence> internally to determine the location
+of each sentence.
+
+Returns an ArrayRef of ArrayRefs where the first item is the starting index and
+the second is the ending index of each sentence in C<$text>.
+
+=cut
 fun _get_offsets( $text ) {
 	# loading here so that utf8::all does not effect everything
 	require Lingua::EN::Sentence;
@@ -56,6 +64,16 @@ fun _get_offsets( $text ) {
 	$offsets;
 }
 
+=func preprocess_for_tts
+
+  fun preprocess_for_tts( $text )
+
+Preprocess C<$text> by using a number of substitutions for common abbreviations
+so that a speech synthesis engine can read the expanded versions.
+
+Returns a C<Str> with the preprocessed text.
+
+=cut
 fun preprocess_for_tts( $text ) {
 	$_ = $text;
 	$_ = unidecode($_); # FIXME this is a sledgehammer approach

--- a/lib/Renard/Incunabula/Language/EN.pm
+++ b/lib/Renard/Incunabula/Language/EN.pm
@@ -65,9 +65,8 @@ fun _get_offsets( $text ) {
 		#
 		# This makes sure that repeated sentences have
 		# different offsets.
-		$str =~ m/$s_re/g;
-		push @$offsets, [ $-[0], $+[0] ];
-
+		$str =~ m/\G(?:.*?)($s_re)/g;
+		push @$offsets, [ $-[1], $+[1] ];
 	}
 
 	$offsets;

--- a/lib/Renard/Incunabula/Language/EN.pm
+++ b/lib/Renard/Incunabula/Language/EN.pm
@@ -18,7 +18,7 @@ fun apply_sentence_offsets_to_blocks( (InstanceOf['String::Tagged']) $text ) {
 	$text->iter_extents_nooverlap(
 		sub {
 			my ( $extent, %tags ) = @_;
-			my $offsets = _get_offsets( $extent->substr );
+			my $offsets = _get_offsets( $extent->substr->str );
 			# NOTE Offsets need to be sorted because it appears that they might not
 			# be in order.  Not sure what that means or if that is a bug.
 			$offsets = [ sort { $a->[0] <=> $b->[0] } @$offsets ];
@@ -53,7 +53,7 @@ fun _get_offsets( $text ) {
 	my $sentences = get_sentences($text);
 
 	my $offsets = [];
-	my $str = $text->str;
+	my $str = $text;
 	for my $s (@$sentences) {
 		my $s_re = $s =~ s/\s+/\\s+/gr;
 		$str =~ m/$s_re/g;

--- a/lib/Renard/Incunabula/Language/EN.pm
+++ b/lib/Renard/Incunabula/Language/EN.pm
@@ -18,9 +18,6 @@ of each sentence.
 
 =cut
 fun apply_sentence_offsets_to_blocks( (InstanceOf['String::Tagged']) $text ) {
-	# loading here so that utf8::all does not effect everything
-	require Lingua::EN::Sentence::Offsets;
-	Lingua::EN::Sentence::Offsets->import(qw/get_offsets add_acronyms/);
 	$text->iter_extents_nooverlap(
 		sub {
 			my ( $extent, %tags ) = @_;
@@ -38,6 +35,25 @@ fun apply_sentence_offsets_to_blocks( (InstanceOf['String::Tagged']) $text ) {
 		},
 		only => [ 'block' ],
 	);
+}
+
+fun get_offsets( $text ) {
+	# loading here so that utf8::all does not effect everything
+	require Lingua::EN::Sentence;
+	Lingua::EN::Sentence->import(qw/get_sentences/);
+
+	my $sentences = get_sentences($text);
+
+	my $offsets = [];
+	my $str = $text->str;
+	for my $s (@$sentences) {
+		my $s_re = $s =~ s/\s+/\\s+/gr;
+		$str =~ m/$s_re/g;
+		push @$offsets, [ $-[0], $+[0] ];
+
+	}
+
+	$offsets;
 }
 
 fun preprocess_for_tts( $text ) {

--- a/lib/Renard/Incunabula/Language/EN.pm
+++ b/lib/Renard/Incunabula/Language/EN.pm
@@ -21,7 +21,7 @@ fun apply_sentence_offsets_to_blocks( (InstanceOf['String::Tagged']) $text ) {
 	$text->iter_extents_nooverlap(
 		sub {
 			my ( $extent, %tags ) = @_;
-			my $offsets = get_offsets( $extent->substr );
+			my $offsets = _get_offsets( $extent->substr );
 			# NOTE Offsets need to be sorted because it appears that they might not
 			# be in order.  Not sure what that means or if that is a bug.
 			$offsets = [ sort { $a->[0] <=> $b->[0] } @$offsets ];
@@ -37,7 +37,7 @@ fun apply_sentence_offsets_to_blocks( (InstanceOf['String::Tagged']) $text ) {
 	);
 }
 
-fun get_offsets( $text ) {
+fun _get_offsets( $text ) {
 	# loading here so that utf8::all does not effect everything
 	require Lingua::EN::Sentence;
 	Lingua::EN::Sentence->import(qw/get_sentences/);

--- a/t/Renard/Incunabula/Language/EN.t
+++ b/t/Renard/Incunabula/Language/EN.t
@@ -3,22 +3,23 @@
 use Test::Most;
 
 use lib 't/lib';
-use Renard::Incunabula::Devel::TestHelper;
-
 use Renard::Incunabula::Common::Setup;
-use Renard::Incunabula::Format::PDF::Document;
-use Renard::Incunabula::Language::EN;
-use Function::Parameters;
 
-my $pdf_ref_path = try {
-	Renard::Incunabula::Devel::TestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
-} catch {
-	plan skip_all => "$_";
-};
+use Renard::Incunabula::Devel::TestHelper;
+use Renard::Incunabula::Language::EN;
+
+use List::AllUtils qw(reduce);
+use Test::Needs;
 
 plan tests => 2;
 
 subtest "Split sentences in PDF" => sub {
+	test_needs 'Renard::Incunabula::Format::PDF::Document';
+	my $pdf_ref_path = try {
+		Renard::Incunabula::Devel::TestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
+	} catch {
+		plan skip_all => "$_";
+	};
 	my $pdf_doc = Renard::Incunabula::Format::PDF::Document->new(
 		filename => $pdf_ref_path
 	);

--- a/t/Renard/Incunabula/Language/EN.t
+++ b/t/Renard/Incunabula/Language/EN.t
@@ -33,7 +33,7 @@ subtest "Split sentences in PDF" => sub {
 		sub {
 			my ( $substring, %tags ) = @_;
 			if( defined $tags{sentence} ) {
-				note "$substring\n=-=";
+				#note "$substring\n=-=";
 				push @sentences, $substring;
 			}
 		},

--- a/t/Renard/Incunabula/Language/EN.t
+++ b/t/Renard/Incunabula/Language/EN.t
@@ -16,9 +16,9 @@ my $pdf_ref_path = try {
 	plan skip_all => "$_";
 };
 
-plan tests => 1;
+plan tests => 2;
 
-subtest "Split sentences" => sub {
+subtest "Split sentences in PDF" => sub {
 	my $pdf_doc = Renard::Incunabula::Format::PDF::Document->new(
 		filename => $pdf_ref_path
 	);
@@ -49,4 +49,23 @@ subtest "Split sentences" => sub {
 			$sentence_with_dot,
 		),
 		'A block is considered its own sentence';
+};
+
+subtest "Get offsets" => sub {
+	my @sentences = (
+		qq|This is a sentence.|,
+		qq|(This is a another.|,
+		qq|These are in parentheses.)|,
+		qq|Tell me, Mr. Anderson, what good is a phone call if you're unable to speak?|,
+		qq|A sentence with too   many    spaces   that    should    be   cleaned.|,
+	);
+
+	my $txt = join " ", @sentences;
+
+	my $offsets = Renard::Incunabula::Language::EN::_get_offsets($txt);
+
+	is scalar @$offsets, scalar @sentences, 'Right number of sentences';
+	my @got_sentences = map { substr $txt, $_->[0], $_->[1] - $_->[0] } @$offsets;
+
+	is_deeply \@got_sentences, \@sentences, 'Same sentences';
 };


### PR DESCRIPTION
   This is because the tests for Lingua::EN::Sentence::Offsets fail due to
    a new release of Lingua::EN::Sentence
    <https://github.com/andrefs/Lingua-EN-Sentence-Offsets/issues/3>.
